### PR TITLE
Remove vertical lines for bordered tables

### DIFF
--- a/css/ace-mantis.css
+++ b/css/ace-mantis.css
@@ -572,6 +572,17 @@ hr {
     border-color: #393939;
 }
 
+/* Mantis 28826: Remove vertical lines for bordered tables. */
+.table-bordered > thead > tr > th,
+.table-bordered > tbody > tr > th,
+.table-bordered > tfoot > tr > th,
+.table-bordered > thead > tr > td,
+.table-bordered > tbody > tr > td,
+.table-bordered > tfoot > tr > td {
+  border-left-width: 0px;
+  border-right-width: 0px;
+}
+
 /* Small devices (tablets, 768px and up) */
 @media (min-width: 768px) {
     .page-content {


### PR DESCRIPTION
Mantis 28826: The tabular presentation used widely in the UI should be changed to be more pleasing to the eye.
Set left and right border with to 0 pixels for all kind of cells in `table-bordered` class.